### PR TITLE
Issue #6: PDS Inspect Tool → PDSView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 build/
 dist/
 eggs
-PDS_Inspect_Tool.egg-info
+*.egg-info
 *.spec
 .DS_Store
 .installed.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# PDS Inspect Tool
+# PDSView
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [TBD] — TBD
+
+Renames the built executable to `PDSView` and updates the documentation to
+reflect the same naming.
 
 ## [0.4.0] - 2019-03-29
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-PDS Inspect Tool
+PDSView
 Copyright 2019 California Institute of Technology
 
 ---

--- a/PACKAGING.rst
+++ b/PACKAGING.rst
@@ -1,9 +1,9 @@
 Packaging
 =========
 
-This documentation is relevant to those who need to build packages of the PDS
-Inspect Tool for specific platforms. If you're looking to download and use the
-PDS Inspect Tool, see the ``README.rst`` file instead.
+This documentation is relevant to those who need to build packages of PDSView
+for specific platforms. If you're looking to download and use PDSView, see the
+``README.rst`` file instead.
 
 
 Requirements
@@ -41,9 +41,8 @@ Building Out
 ------------
 
 Building the platform-specific installers leverages Buildout_.  The Buildout
-bootstrapper script, ``boostrap.py`` is included with the PDS Inspect Tool
-source.  Simply do the following (adjusting paths and platform-specifics as
-needed):
+bootstrapper script, ``boostrap.py`` is included with PDSView source.  Simply
+do the following (adjusting paths and platform-specifics as needed):
 
 1. Use the Python from your vitualenv to bootstrap:
    ``/tmp/mypython/bin/python2.7 bootstrap.py``
@@ -53,15 +52,18 @@ Then, run the platform-specific installation:
 
 For Windows
     ``bin/buildout install windows``. This will create
-    ``dist/PDS-Inspect-Tool.exe`` which Windows users can double-click
-    to run.
+    ``dist/PDSView.exe`` which Windows users can double-click to run. Or do
+    ``bin/buildout install windows-dir`` to create
+    ``dist/PDSView``, which contains a hundred different support files plus
+    the ``PDSView.exe`` executable. This version launches faster but comes
+    as a full directory of files, while the single ``.exe`` launches much
+    more slowly but ships more conveniently.
 For macOS
     ``bin/buildout install macos``. This will create
-    ``dist/PDS-Inspect-Tool.app`` which macOS users can double-click
-    to run.
+    ``dist/PDSView.app`` which macOS users can double-click to run.
 For Linux
     ``bin/buildout install linux``. This will create
-    ``dist/PDS-Inspect-Tool`` which Linux users can run.
+    ``dist/PDSView`` which Linux users can run.
 
 You can optionally compress the target files/directories prior to distribution
 if you wish.

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,8 @@
-===================
- PDS Inspect Tool
-===================
+=========
+ PDSView
+=========
 
-The PDS Inspect Tool provides support for visualizing PDS3 and PDS4 data
-products.
+The PDSView tool provides support for visualizing PDS3 and PDS4 data products.
 
 
 Features
@@ -16,36 +15,35 @@ Features
 Installation
 ============
 
-Prebuilt packages of the PDS Inspect Tool are available; simply download the
-version relevant to your platform from the project's GitHub releases_ page
-(click "Assets" under your chosen release version). Details for each platform
-are given below.
+Prebuilt packages of PDSView are available; simply download the version
+relevant to your platform from the project's GitHub releases_ page (click
+"Assets" under your chosen release version). Details for each platform are
+given below.
 
 
 Linux
 -----
 
-Download and unpack ``PDS-Inspect-Tool-linux.zip`` to extract the executable
-file ``PDS-Inspect-Tool``; run this file. Note you'll need to be running the X
-Window System. Depending on your window manager, you may be able to drag files
-from the file explorer on your platform directly into the PDS Inspect Tool's
-main window. Otherwise, choose "Open" from the tool's "File" menu to open PDS
-data products.
+Download and unpack ``PDSView-linux.zip`` to extract the executable file
+``PDSView``; run this file. Note you'll need to be running the X Window
+System. Depending on your window manager, you may be able to drag files from
+the file explorer on your platform directly into PDSView's main window.
+Otherwise, choose "Open" from the tool's "File" menu to open PDS data
+products.
 
 
 macOS
 -----
 
-Download and unpack ``PDS-Inspect-Tool-macOS.zip`` to extract the executable
-``PDS-Inspect-Tool.app`` which you can drag to your ``/Applications`` folder
-or other convenient location. Note that because this is an unsigned_ program,
-you will need to control-click (⌃+click) or right-click its icon and choose
-"Open", followed by clicking the "Open" button, to start the PDS Inspect Tool.
-The tool is known to work on the following versions of macOS:
+Download and unpack ``PDSView-macOS.zip`` to extract the executable
+``PDSView.app`` which you can drag to your ``/Applications`` folder or other
+convenient location. Note that because this is an unsigned_ program, you will
+need to control-click (⌃+click) or right-click its icon and choose "Open",
+followed by clicking the "Open" button, to start PDSView. The tool is known to
+work on the following versions of macOS:
 
 • 10.13.6 "High Sierra"
-• 10.14.3 "Mojave"
-• 10.14.4 "Mojave"
+• 10.14.3–6 "Mojave"
 
 Other releases may or may not work. In addition, drag-and-drop from Finder or
 the desktop is not guaranteed to work on macOS at all. In this case, choosing
@@ -58,16 +56,16 @@ Windows
 Two downloads are provided and tested on 64-bit Windows version 10. These
 versions are identical except as noted below:
 
-• ``PDS-Inspect-Tool-Windows-single-exe.zip``. Downloading and unpacking this
-  archive yields a single executable file ``PDS-Inspect-Tool.exe`` that you
-  can double-click to launch. Note that it may take a *long* time for the tool
-  to launch and its initial window to appear. *Pro*: single, easy to find
-  ``.exe`` file. *Con*: Slow time to start the program.
-• ``PDS-Inspect-Tool-Windows-dir.zip``. Downloading and unpacking this archive
-  yields a directory of many files with a ``PDS-Inspect-Tool.exe`` file
-  inside. Double-click this file to launch; the window will appear much
-  faster. *Pro*: Fast start. *Con*: harder to find the ``.exe`` file in a
-  directory littered with hundreds of other files.
+• ``PDSView-single-exe.zip``. Downloading and unpacking this archive yields a
+  single executable file ``PDSView.exe`` that you can double-click to launch.
+  Note that it may take a *long* time for the tool to launch and its initial
+  window to appear. *Pro*: single, easy to find ``.exe`` file. *Con*: Slow
+  time to start the program.
+• ``PDSView-dir.zip``. Downloading and unpacking this archive yields a
+  directory of many files with a ``PDSView.exe`` file inside. Double-click
+  this file to launch; the window will appear much faster. *Pro*: Fast start.
+  *Con*: harder to find the ``.exe`` file in a directory littered with
+  hundreds of other files.
 
 Which one you use is a matter of preference. Regardless, drag-and-drop from
 the Windows desktop or file Explorer works fine. (Other versions of Windows
@@ -100,13 +98,13 @@ For example, a Unix-like (including macOS-like) system could do the following::
     virtualenv --system-site-packages /tmp/mypython
     cd /tmp/mypthon
     bin/pip install http://pdssbn.astro.umd.edu/ftp/tools/readpds_python/1.0/PDS4_tools-1.0.zip
-    # == Download and extract the PDS Inspect Tool ==
-    curl -L 'https://github.com/NASA-PDS-Incubator/pds-inspect-tool/archive/v0.1-beta.tar.gz' | tar xzf -
-    cd pds-inspect-tool-0.1-beta
+    # == Download and extract the PDSView tool ==
+    curl -L 'https://github.com/NASA-PDS-Incubator/pds-view/archive/v0.1-beta.tar.gz' | tar xzf -
+    cd pds-view-0.1-beta
     # == Install its dependencies ==
     ../bin/python setup.py develop
     # == Run it ==
-    env MPLBACKEND=Qt4Agg ../bin/PDS-Inspect-Tool
+    env MPLBACKEND=Qt4Agg ../bin/PDSView
 
 Adjust the above commands as needed for your platform.
 
@@ -115,7 +113,8 @@ Documentation
 =============
 
 Additional documentation is available in the ``docs`` directory and at
-https://pds-cm.jpl.nasa.gov/pds4/preparation/inspect/
+https://pds-cm.jpl.nasa.gov/pds4/preparation/inspect/ … note this is only
+available within the Jet Propulsion Laborary.
 
 
 Translations
@@ -127,8 +126,8 @@ This product has not been translated into any other languages than US English.
 Contribute
 ==========
 
-• Issue Tracker: https://github.com/NASA-PDS-Incubator/pds-inspect-tool/issues
-• Source Code: https://github.com/NASA-PDS-Incubator/pds-inspect-tool
+• Issue Tracker: https://github.com/NASA-PDS-Incubator/pds-view/issues
+• Source Code: https://github.com/NASA-PDS-Incubator/pds-view
 
 
 Support

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,7 +31,7 @@ cmds =
     ${buildout:bin-directory}/pyinstaller \
         ${pyinstaller:options-unix} \
         --windowed \
-        --osx-bundle-identifier "gov.nasa.jpl.pds.apps.PDS-Inspect-Tool" \
+        --osx-bundle-identifier "gov.nasa.jpl.pds.apps.PDSView" \
         ${buildout:bin-directory}/${buildout:package-name}    
 
 [windows]
@@ -39,6 +39,11 @@ cmds =
 recipe = collective.recipe.cmd
 on_install = true
 cmds = ${buildout:bin-directory}/pyinstaller ${pyinstaller:options-windows} --onefile --windowed --version-file "${buildout:directory}/etc/version-info.txt" --name "${buildout:package-name}" "${buildout:bin-directory}/${buildout:package-name}-script.py"
+
+[windows-dir]
+# Same as [windows], but instead of a single file, makes a directory
+< windows
+cmds = ${buildout:bin-directory}/pyinstaller ${pyinstaller:options-windows} --windowed --version-file "${buildout:directory}/etc/version-info.txt" --name "${buildout:package-name}" "${buildout:bin-directory}/${buildout:package-name}-script.py"
 
 [linux]
 recipe = collective.recipe.cmd

--- a/docs/site/site.xml
+++ b/docs/site/site.xml
@@ -32,25 +32,25 @@
 # POSSIBILITY OF SUCH DAMAGE.
 -->
 
-<project name="Inspect Tool">
+<project name="PDSView">
   <bannerLeft>
     <src>images/pds4_logo.png</src>
     <href>https://pds-cm.jpl.nasa.gov/pds4/</href>
   </bannerLeft>
 
   <bannerRight>
-    <name>Inspect Tool</name>
+    <name>PDSView</name>
   </bannerRight>
 
   <version/>
 
   <body>
     <links>
-      <item name="Inspect" href="https://pds-cm.jpl.nasa.gov/pds4/preparation/inspect/index.html" />
+      <item name="PDSView" href="https://pds-cm.jpl.nasa.gov/pds4/preparation/inspect/index.html" />
     </links>
 
     <menu name="Software Documentation">
-      <item name="About Inspect Tool" href="index.html"/>
+      <item name="About PDSView" href="index.html"/>
       <item name="Installation" href="install/index.html"/>
       <item name="Operation" href="operate/index.html"/>
     </menu>

--- a/docs/site/xdoc/index.xml
+++ b/docs/site/xdoc/index.xml
@@ -34,13 +34,13 @@
 
 <document>
   <properties>
-    <title>About Inspect Tool</title>
+    <title>About PDSView</title>
     <author email="Sean.Hardman@jpl.nasa.gov">Sean Hardman</author>
   </properties>
 
   <body>
-    <section name="About Inspect Tool">
-      <p>The Inspect Tool provides support for visualizing PDS3 and PDS4 data products.
+    <section name="About PDSView">
+      <p>PDSView provides support for visualizing PDS3 and PDS4 data products.
       </p>
 
       <p>Please send comments, change requests and bug reports to the <a href="mailto:pds_operator@jpl.nasa.gov">PDS Operator</a> at pds_operator@jpl.nasa.gov.

--- a/docs/site/xdoc/install/index-py-gen.xml.vm
+++ b/docs/site/xdoc/install/index-py-gen.xml.vm
@@ -41,11 +41,11 @@
 
   <body>
     <section name="Python Dependency Installation for General Platform">
-      <p>This document describes how to install the Python dependencies for the Inspect Tool contained in the <i>${project.artifactId}</i> package on a general platform.
+      <p>This document describes how to install the Python dependencies for PDSView contained in the <i>${project.artifactId}</i> package on a general platform.
       </p>
 
       <subsection name="Dependencies">
-        <p>The following modules must be installed in order to run the Inspect Tool:
+        <p>The following modules must be installed in order to run PDSView:
         </p>
 
         <ul>
@@ -107,7 +107,7 @@ or
              <p><i>    # error(</i>=</p>
              <p><i>          # "This version of PyQt4 and the commercial version of Qt have "</i></p>
              <p><i>          # "incompatible licenses.”)</i></p>
-          <li>Try running the Inspect Tool again:</li>
+          <li>Try running PDSView again:</li>
             <p> You may get the following error:</p>
             <p> <i>RuntimeError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework. See the Python documentation for more information on installing Python as a framework on Mac OS X. Please either reinstall Python as a framework, or try one of the other backends. If you are using (Ana)Conda please install python.app and replace the use of 'python' with 'pythonw'. See 'Working with Matplotlib on OSX' in the Matplotlib FAQ for more information.</i></p>
             <p> If so try the following steps:</p>

--- a/docs/site/xdoc/install/index-py-mac.xml.vm
+++ b/docs/site/xdoc/install/index-py-mac.xml.vm
@@ -41,7 +41,7 @@
 
   <body>
     <section name="Python Dependency Installation for Mac OS X">
-      <p>This document describes how to install the Python dependencies for the Inspect Tool contained in the <i>${project.artifactId}</i> package on the Mac OS X platform.
+      <p>This document describes how to install the Python dependencies for PDSView contained in the <i>${project.artifactId}</i> package on the Mac OS X platform.
       </p>
 
       <subsection name="Mac Ports">
@@ -107,7 +107,7 @@ OpenSSL 1.0.2o  27 Mar 2018
 % sudo pip install PDS4_tools-X.X.zip
         </source>
 
-        <p>With successful installation of the PDS4 Tools package, the target computer should support execution of the Inspect Tool.
+        <p>With successful installation of the PDS4 Tools package, the target computer should support execution of PDSView.
         </p>
       </subsection>
     </section>

--- a/docs/site/xdoc/install/index.xml.vm
+++ b/docs/site/xdoc/install/index.xml.vm
@@ -41,7 +41,7 @@
 
   <body>
     <section name="Installation">
-      <p>This document describes how to install the Inspect Tool contained in the <i>${project.artifactId}</i> package. The following topics can be found in this document:
+      <p>This document describes how to install PDSView contained in the <i>${project.artifactId}</i> package. The following topics can be found in this document:
       </p>
 
       <ul>
@@ -52,11 +52,11 @@
     </section>
 
     <section name="System Requirements">
-      <p>This section details the system requirements for installing and operating the Inspect Tool software.
+      <p>This section details the system requirements for installing and operating the PDSView software.
       </p>
 
       <subsection name="Python">
-        <p>The Inspect Tool software was developed using Python and will run on any platform with a supported Python environment. It is compatible with Python 2.6 or 2.7 (Python above 2.7.8 is recommended). It is not compatible with Python 2.5 or earlier versions; or currently with Python 3. The following commands test the local Python installation in a UNIX-based environment:
+        <p>PDSView was developed using Python and will run on any platform with a supported Python environment. It is compatible with Python 2.6 or 2.7 (Python above 2.7.8 is recommended). It is not compatible with Python 2.5 or earlier versions; or currently with Python 3. The following commands test the local Python installation in a UNIX-based environment:
         </p>
 
         <source>
@@ -67,12 +67,12 @@
 Python 2.7.12
         </source>
 
-        <p>The first command above checks whether the <i>python</i> executable is in the environment's path and the second command reports the version. If Python is not installed or the version is not 2.7 (python versions above 2.7.8 are recommended for easier installation of the Inspect Tool), Python will need to be downloaded and installed in the current environment. Consult the local system administrator for installation of this software on networked machines.  Most systems should have both Python 2.7 and Python 3 installed.  On local machines, current versions of <i>python</i> can be downloaded from <a href="https://www.python.org/downloads/">Python download page</a>
+        <p>The first command above checks whether the <i>python</i> executable is in the environment's path and the second command reports the version. If Python is not installed or the version is not 2.7 (python versions above 2.7.8 are recommended for easier installation of PDSView), Python will need to be downloaded and installed in the current environment. Consult the local system administrator for installation of this software on networked machines.  Most systems should have both Python 2.7 and Python 3 installed.  On local machines, current versions of <i>python</i> can be downloaded from <a href="https://www.python.org/downloads/">Python download page</a>
         </p>
       </subsection>
 
       <subsection name="Python Dependencies">
-        <p>The Inspect Tool software has dependencies on a number of Python libraries. In the future the code will be packaged as a standalone executable. However for now, utilize one of the following procedures for installing these dependencies on your target platform:
+        <p>The PDSView software has dependencies on a number of Python libraries. In the future the code will be packaged as a standalone executable. However for now, utilize one of the following procedures for installing these dependencies on your target platform:
         </p>
 
         <ul>
@@ -113,14 +113,14 @@ or
           </p>
         </li>
         <li><b>doc/</b><br/>
-          <p>This directory contains a local web site with the Inspect Tool documentation and other configuration management related information. Just point the desired web browser to the <i>index.html</i> file in this directory.
+          <p>This directory contains a local web site with PDSView documentation and other configuration management related information. Just point the desired web browser to the <i>index.html</i> file in this directory.
           </p>
         </li>
       </ul>
     </section>
 
     <section name="Configuring the Environment">
-      <p>In order to manage and interact with the Inspect Tool, the local environment must first be configured appropriately. This section describes how to setup the user environment on UNIX-based and Windows machines.
+      <p>In order to manage and interact with PDSView, the local environment must first be configured appropriately. This section describes how to setup the user environment on UNIX-based and Windows machines.
       </p>
 
       <subsection name="UNIX-Based Environment">

--- a/docs/site/xdoc/operate/index.xml.vm
+++ b/docs/site/xdoc/operate/index.xml.vm
@@ -40,7 +40,7 @@
 
   <body>
     <section name="Operation">
-      <p>This document describes how to operate the Inspect Tool. The following topics can be found in this document:
+      <p>This document describes how to operate PDSView. The following topics can be found in this document:
       </p>
 
       <ul>
@@ -59,7 +59,7 @@
     </section>
 
     <section name="Feedback">
-      <p>The Inspect Tool is under development. Future releases will:
+      <p>PDSView is under development. Future releases will:
       </p>    
 
       <ul>
@@ -72,7 +72,7 @@
         </ul> 
       </ul>
 
-      <p>Please send any feedback (likes/dislikes, bugs, suggested features) to <a href="mailto:james.e.hofman@jpl.nasa.gov">Inspect Tool Feedback</a>
+      <p>Please send any feedback (likes/dislikes, bugs, suggested features) to <a href="mailto:james.e.hofman@jpl.nasa.gov">PDSView Feedback</a>
       </p>
     </section>
   </body>

--- a/etc/version-info.txt
+++ b/etc/version-info.txt
@@ -31,12 +31,12 @@ VSVersionInfo(
         u'040904b0',
         [StringStruct(u'Comments', u'https://pds.nasa.gov/'),
         StringStruct(u'CompanyName', u'Planetary Data System'),
-        StringStruct(u'FileDescription', u'PDS Inspect Tool'),
+        StringStruct(u'FileDescription', u'PDSView'),
         StringStruct(u'FileVersion', u'0,4,0,0'),
-        StringStruct(u'InternalName', u'PDS_Inspect_Tool'),
+        StringStruct(u'InternalName', u'PDSView'),
         StringStruct(u'LegalCopyright', u'Copyright © 2019 Caltech.'),
-        StringStruct(u'OriginalFilename', u'PDS_Inspect_Tool.exe'),
-        StringStruct(u'ProductName', u'PDS Inspect Tool 0.4.0-dev 2019'),
+        StringStruct(u'OriginalFilename', u'PDSView.exe'),
+        StringStruct(u'ProductName', u'PDSView 0.4.0-dev 2019'),
         StringStruct(u'ProductVersion', u'0,4,0,0')])
       ]), 
     VarFileInfo([VarStruct(u'Translation', [0, 1200])])

--- a/pds_inspect_tool/View.py
+++ b/pds_inspect_tool/View.py
@@ -692,7 +692,7 @@ class MainWindow(QMainWindow):
         # Hide main toolbar until a file is loaded.
         self.mainToolBar.hide()
         self.initial_gray_scale_setting()
-        self.setWindowTitle("PDS Inspect Tool")
+        self.setWindowTitle("PDSView")
         self.setWindowIcon(QIcon(resource_path("./Icons/MagGlass.png")))
 
     def close_app(self):

--- a/setup.py
+++ b/setup.py
@@ -50,22 +50,22 @@ requirements = [
     'matplotlib==2.2.3',              # 3.0.0 and later require Python 3
     'backports.functools_lru_cache',  # matplotlib fails to declare this dependency
     'seaborn==0.9.0',                 # May as well pin this version too for future resiliency
-    'pillow',                         # Needed by PDS-Inspect-Tool
-    'airspeed',                       # Needed by PDS-Inspect-Tool
+    'pillow',                         # Needed by PDSView
+    'airspeed',                       # Needed by PDSView
     'six',                            # Needed for PyInstaller
 ]
 
 setup(
-    name='PDS-Inspect-Tool',
-    version='0.4.0-dev',
-    description="PDS Inspect Tool",
+    name='PDSView',
+    version='0.4.0dev0',
+    description="PDSView tool for viewing PDS products",
     long_description=readme + '\n\n' + changes,
     author="Sean Hardman,Jim Hofman",
     author_email='Sean.Hardman@jpl.nasa.gov,James.E.Hofman@jpl.nasa.gov',
-    url='https://github.jpl.nasa.gov/PDSEN/pds-inspect-tool',
+    url='https://github.com/NASA-PDS-Incubator/pds-view',
     entry_points={
         # This should be `gui_scripts` but I get no script generated
-        'console_scripts': ['PDS-Inspect-Tool=pds_inspect_tool.View:main']
+        'console_scripts': ['PDSView=pds_inspect_tool.View:main']
     },
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     package_data={


### PR DESCRIPTION
Rename usage of "PDS Inspect Tool" to simply "PDSView", in documentation and also in file artifact naming. This ought to resolve #6 